### PR TITLE
Simplify number to letter computation using wrap instead of mod

### DIFF
--- a/src/PuzzleTools.livecodescript
+++ b/src/PuzzleTools.livecodescript
@@ -12,7 +12,7 @@ end toNumber
 
 function fromNumber pNum
    local tNum
-   put ((pNum - 1) mod 26) + 65 into tNum
+   put (pNum wrap 26) + 64 into tNum
    return numtochar(tNum)
 end fromNumber
 


### PR DESCRIPTION
Use a simpler method for computing the uppercase letter corresponding to a given number using wrap instead of mod.